### PR TITLE
解决 token 过期问题，前端自动刷新 token 

### DIFF
--- a/src/api/user.js
+++ b/src/api/user.js
@@ -8,11 +8,11 @@ export function login(data) {
   })
 }
 
-export function refreshtoken(data) {
+export function refreshtoken(token) {
   return request({
-    url: '/refreshtoken',
-    method: 'post',
-    data
+    url: '/refresh_token',
+    method: 'get',
+    params: { 'token': token }
   })
 }
 

--- a/src/permission.js
+++ b/src/permission.js
@@ -3,7 +3,7 @@ import store from './store'
 import { Message } from 'element-ui'
 import NProgress from 'nprogress' // progress bar
 import 'nprogress/nprogress.css' // progress bar style
-import { getToken } from '@/utils/auth' // get token from cookie
+import { getToken, parseJwt } from '@/utils/auth' // get token from cookie
 import getPageTitle from '@/utils/get-page-title'
 
 NProgress.configure({ showSpinner: false }) // NProgress Configuration
@@ -29,6 +29,12 @@ router.beforeEach(async(to, from, next) => {
       // determine whether the user has obtained his permission roles through getInfo
       const hasRoles = store.getters.roles && store.getters.roles.length > 0
       if (hasRoles) {
+        // Verify token whether expire, if expired, will refresh token.
+        var JwtToken = parseJwt(hasToken)
+        var expiredTime = new Date(JwtToken.exp * 1000)
+        if (expiredTime < new Date()) {
+          await store.dispatch('user/refreshToken')
+        }
         next()
       } else {
         try {

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -96,7 +96,7 @@ const actions = {
   // 刷新token
   refreshToken({ commit, state }) {
     return new Promise((resolve, reject) => {
-      refreshtoken({ token: state.token }).then(response => {
+      refreshtoken(state.token).then(response => {
         const { token } = response
         commit('SET_TOKEN', token)
         setToken(token)

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -13,3 +13,14 @@ export function setToken(token) {
 export function removeToken() {
   return Cookies.remove(TokenKey)
 }
+
+export function parseJwt(token) {
+  var base64Url = token.split('.')[1]
+  var base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/')
+  var jsonPayload = decodeURIComponent(atob(base64).split('').map(function(c) {
+    return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+  }).join(''))
+
+  return JSON.parse(jsonPayload)
+}
+


### PR DESCRIPTION
## 背景
* 当前如果 token 过期，即使用户在登录状态下，也是需要再次登录;

* 而`Jwt token`并不能很好的支持后端程序解决这个问题，因为 token 就已经包含了过期时间，修改了这个时间，token 也就没有了意义。详见讨论[jwt-json-web-token-automatic-prolongation-of-expiration](https://stackoverflow.com/questions/26739167/jwt-json-web-token-automatic-prolongation-of-expiration)

## 解决点
* 依赖go-admin 接口 /refresh_token 刷新当前用户的 token.

## 修改点
1. `src/permission.js` 当前如果已经有用户的相关信息就在前端校验一下 token 是否过期，如果过期就刷新并保存token.

